### PR TITLE
Add SSH fingerprints to user docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source 'https://rubygems.org'
 
 gem "jekyll", "~> 3.9.0"
 
-gem "html-proofer"
+gem "html-proofer", "~> 4.1"
 
-gem "just-the-docs"
+gem "just-the-docs", "~> 0.3.3"
 
-gem "webrick"
+gem "webrick", "~> 1.7.0"
 
 gem "github-pages", "~> 215", group: :jekyll_plugins

--- a/about/hardware.md
+++ b/about/hardware.md
@@ -65,7 +65,7 @@ information about requesting GPUs.
 ### Internet Access
 Workers can not resolve [domain names](https://en.wikipedia.org/wiki/Domain_name), and as a result, most internet services may not function correctly. For example,
 
-- Cloning a git repository from [github.com]()
+- Cloning a git repository from [github.com](https://github.com/)
 - Downloading packages using `spack`, `pip`, `conda` or `Pkg.jl`
 - Downloading files with `wget`, `rclone` or `curl` from the Internet
 

--- a/getting_started/connecting.md
+++ b/getting_started/connecting.md
@@ -17,7 +17,25 @@ ssh andrewID@arjuna.psc.edu
 As Arjuna is on the CMU network, the above command will only work if you are also
 connected to the CMU Network (i.e. you are on campus).
 
-When you first login to Arjuna, you will be prompted for a password.  Enter the password given to you by the Administrator who created your account. You will be immediately required to change it. 
+When you first login to Arjuna, you will be prompted for a password.  Enter the password given to you by the Administrator who created your account. You will be immediately required to change it.
+
+### Arjuna's SSH key fingerprints
+
+Public Key fingerprints are used to validate the connection to a remote server.
+When connecting to a server for the first time you will be prompted to verify
+the authenticity of the server, by comparing the fingerprint of the server's to
+what your expect it to be.
+
+Arjuna's public key fingerprints are:
+
+| Fingerprint | Key Type |
+| ----------- | -------- |
+| `SHA256:ZqL9rq+2S7T/1gfdtlITQ9KpsPO+jgTdU0mmN54Xklk` | RSA |
+| `SHA256:RWDQtpas1JNmy9/7vHpdMLA8QGG25RsNlfRWJSazecY` | ECDSA |
+| `SHA256:K/PT04x+Ohdtb68ogH1SC+kvFqUGrC+itbsXz/tcuB8` | ED25519 |
+
+> You **should not** connect to Arjuna if the fingerprints do not match.
+> Please open an [issue](https://github.com/ArjunaCluster/ArjunaUsers/issues)
 
 ### Accessing Arjuna via CMU's VPN
 

--- a/getting_started/connecting.md
+++ b/getting_started/connecting.md
@@ -17,14 +17,14 @@ ssh andrewID@arjuna.psc.edu
 As Arjuna is on the CMU network, the above command will only work if you are also
 connected to the CMU Network (i.e. you are on campus).
 
-When you first login to Arjuna, you will be prompted for a password.  Enter the password given to you by the Administrator who created your account. You will be immediately required to change it.
+When you first log in to Arjuna, you will be prompted for a password.  Enter the password given to you by the Administrator who created your account. You will be immediately required to change it.
 
 ### Arjuna's SSH key fingerprints
 
 Public Key fingerprints are used to validate the connection to a remote server.
 When connecting to a server for the first time you will be prompted to verify
-the authenticity of the server, by comparing the fingerprint of the server's to
-what your expect it to be.
+the authenticity of the server, by comparing the server's reported fingerprint to
+the expected fingerprint.
 
 Arjuna's public key fingerprints are:
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # Pull the baseurl from _config.yml
-BASEURL ?= $(shell grep baseurl _config.yml | awk '{print $2}')
+BASEURL ?= $(word 2, $(shell grep baseurl _config.yml))
 
 build: _site/
 

--- a/makefile
+++ b/makefile
@@ -18,7 +18,6 @@ test: _site/
 	bundle exec htmlproofer \
 	--allow-hash-href \
 	--disable-external \
-	--check-html --check-img-http --enforce-https \
 	_site/
 
 # Build and serve the site for viewing locally


### PR DESCRIPTION
Adds Arjuna's ssh fingerprints to the docs, so users can verify the authenticity
of the cluster when connecting. Some other notable systems that also do this:

- [XSEDE](https://www.xsede.org/ecosystem/operations/ssh-keys)
- [Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)

Other tweaks:

- Handle the update to html-proofer
- Fix missing link to github in the docs
- Drop dep on awk from makefile
