### PR TITLE
Document Reserved Cores

### DIFF
--- a/about/hardware.md
+++ b/about/hardware.md
@@ -52,6 +52,10 @@ memory per requested CPU. See [Allocating Resources] for more information.
 For more information on the partitions and their default settings run
 `scontrol show partitions` on Arjuna.
 
+> We reserve 2 cores per node for system usage (i.e. the [slurmd daemon](../getting_started/slurm_intro.md)).
+> These cores are not available for jobs. For example, a node from the `gpu` partition has up to 62 cores per node
+> available for jobs.
+
 ### GPU Nodes
 
 Each GPU Nodes has 4 [K80 NVIDIA GPUs] available for usage. To request a gpu, use

--- a/about/hardware.md
+++ b/about/hardware.md
@@ -52,7 +52,7 @@ memory per requested CPU. See [Allocating Resources] for more information.
 For more information on the partitions and their default settings run
 `scontrol show partitions` on Arjuna.
 
-> We reserve 2 cores per node for system usage (i.e. the [slurmd daemon](../getting_started/slurm_intro.md)).
+> We reserve 2 cores per node for system usage (e.g. the [slurmd daemon](../getting_started/slurm_intro.md)).
 > These cores are not available for jobs. For example, a node from the `gpu` partition has up to 62 cores per node
 > available for jobs.
 

--- a/makefile
+++ b/makefile
@@ -16,8 +16,8 @@ _site/: Gemfile.lock _config.yml $(SRC)
 # Run test on the website using htmlproofer
 test: _site/
 	bundle exec htmlproofer \
-	--allow-hash-href \
-	--disable-external \
+	--root-dir=_site/ \
+	--disable-external=true \
 	_site/
 
 # Build and serve the site for viewing locally


### PR DESCRIPTION
It's come up a few times (#165, #75) ; let's document it here

Strictly speaking, we reserved one core per socket (`CoreSpecCount=1`), and the nodes have 2 sockets. I think that's extraneous info, so I just said we reserve 2 cores.  